### PR TITLE
Added SchemaName property to MssqlDatabaseProvider

### DIFF
--- a/src/Simple.Migrations/DatabaseProvider/MssqlDatabaseProvider.cs
+++ b/src/Simple.Migrations/DatabaseProvider/MssqlDatabaseProvider.cs
@@ -13,6 +13,11 @@ namespace SimpleMigrations.DatabaseProvider
     public class MssqlDatabaseProvider : DatabaseProviderBaseWithAdvisoryLock
     {
         /// <summary>
+        /// Schema name used to store the version table.
+        /// </summary>
+        public string SchemaName { get; set; } = "dbo";
+
+        /// <summary>
         /// Gets or sets the name of the advisory lock to acquire
         /// </summary>
         public string LockName { get; set; } = "SimpleMigratorExclusiveLock";
@@ -58,9 +63,9 @@ namespace SimpleMigrations.DatabaseProvider
         /// <returns>SQL to create the version table</returns>
         public override string GetCreateVersionTableSql()
         {
-            return $@"IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID('[dbo].[{this.TableName}]') AND type in (N'U'))
+            return $@"IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID('[{this.SchemaName}].[{this.TableName}]') AND type in (N'U'))
                 BEGIN
-                CREATE TABLE [dbo].[{this.TableName}](
+                CREATE TABLE [{this.SchemaName}].[{this.TableName}](
                     [Id] [int] IDENTITY(1,1) PRIMARY KEY NOT NULL,
                     [Version] [bigint] NOT NULL,
                     [AppliedOn] [datetime] NOT NULL,
@@ -75,7 +80,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <returns>SQL to fetch the current version from the version table</returns>
         public override string GetCurrentVersionSql()
         {
-            return $@"SELECT TOP 1 [Version] FROM [dbo].[{this.TableName}] ORDER BY [Id] desc;";
+            return $@"SELECT TOP 1 [Version] FROM [{this.SchemaName}].[{this.TableName}] ORDER BY [Id] desc;";
         }
 
         /// <summary>
@@ -84,7 +89,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <returns>SQL to update the current version in the version table</returns>
         public override string GetSetVersionSql()
         {
-            return $@"INSERT INTO [dbo].[{this.TableName}] ([Version], [AppliedOn], [Description]) VALUES (@Version, GETDATE(), @Description);";
+            return $@"INSERT INTO [{this.SchemaName}].[{this.TableName}] ([Version], [AppliedOn], [Description]) VALUES (@Version, GETDATE(), @Description);";
         }
     }
 }


### PR DESCRIPTION
In case of multiple migration sets, for example from different components this is a useful feature to separate migration history in each schema. 