### PR TITLE
Wrap .DefinedTypes in Try/Catch and handle error

### DIFF
--- a/src/Simple.Migrations/AssemblyMigrationProvider.cs
+++ b/src/Simple.Migrations/AssemblyMigrationProvider.cs
@@ -34,7 +34,17 @@ namespace SimpleMigrations
         /// <returns>All migration info</returns>
         public IEnumerable<MigrationData> LoadMigrations()
         {
-            var migrations = from type in this.migrationAssembly.DefinedTypes
+            IEnumerable<TypeInfo> definedTypes;
+            try
+            {
+                definedTypes = this.migrationAssembly.DefinedTypes;
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                definedTypes = e.Types.Where(t => t != null).Select(t => t.GetTypeInfo());
+            }
+
+            var migrations = from type in definedTypes
                              let attribute = type.GetCustomAttribute<MigrationAttribute>()
                              where attribute != null
                              where this.migrationNamespace == null || type.Namespace == this.migrationNamespace


### PR DESCRIPTION
Using the DefinedTypes call was throwing exceptions when running through integration tests. As far as I can tell, this is a matter of the DLL not being a specific dependency of the integration test suite itself. Workaround presented in the this PR is pulled from http://haacked.com/archive/2012/07/23/get-all-types-in-an-assembly.aspx/

Add a try/catch in AssemblyMigrationProvider LoadMigration call to Assembly.DefinedTypes. If the ReflectionTypeLoadException is caught, attempt to get the type information from the non-null types in the exception.