### PR TITLE
Feature/optional ensure prerequisites

### DIFF
--- a/src/Simple.Migrations.UnitTests/MockDatabaseProvider.cs
+++ b/src/Simple.Migrations.UnitTests/MockDatabaseProvider.cs
@@ -11,6 +11,8 @@ namespace Simple.Migrations.UnitTests
     {
         public long CurrentVersion;
         public DbConnection Connection;
+        
+        public bool EnsurePrerequisitesCreated { get; }
 
         public DbConnection BeginOperation()
         {

--- a/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBase.cs
+++ b/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBase.cs
@@ -42,12 +42,26 @@ namespace SimpleMigrations.DatabaseProvider
         public string TableName { get; set; } = "VersionInfo";
 
         /// <summary>
+        /// Flag provided to ensure that the schema (if appropriate) and version table are created
+        /// </summary>
+        public bool EnsurePrerequisitesCreated { get; }
+
+        /// <summary>
         /// If > 0, specifies the maximum length of the 'Description' field. Descriptions longer will be truncated
         /// </summary>
         /// <remarks>
         /// Database providers which put a maximum length on the Description field should set this to that length
         /// </remarks>
         protected int MaxDescriptionLength { get; set; }
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="DatabaseProviderBase"/> class
+        /// </summary>
+        /// <param name="ensurePrerequisitesCreated">Flag provided to ensure that the schema (if appropriate) and version table are created</param>
+        protected DatabaseProviderBase(bool ensurePrerequisitesCreated)
+        {
+            this.EnsurePrerequisitesCreated = ensurePrerequisitesCreated;
+        } 
 
         /// <summary>
         /// Ensures that the schema (if appropriate) and version table are created, and returns the current version.

--- a/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBaseWithAdvisoryLock.cs
+++ b/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBaseWithAdvisoryLock.cs
@@ -27,7 +27,9 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="DatabaseProviderBaseWithAdvisoryLock"/> class
         /// </summary>
         /// <param name="connection">Database connection to use for all operations</param>
-        public DatabaseProviderBaseWithAdvisoryLock(DbConnection connection)
+        /// <param name="ensurePrerequisitesCreated">Flag provided to ensure that the schema (if appropriate) and version table are created</param>
+        public DatabaseProviderBaseWithAdvisoryLock(DbConnection connection, bool ensurePrerequisitesCreated)
+            : base(ensurePrerequisitesCreated)
         {
             this.Connection = connection;
             if (this.Connection.State != ConnectionState.Open)

--- a/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBaseWithVersionTableLock.cs
+++ b/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBaseWithVersionTableLock.cs
@@ -47,7 +47,9 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="DatabaseProviderBaseWithVersionTableLock"/> class
         /// </summary>
         /// <param name="connectionFactory">Factory to be used to create new connections</param>
-        public DatabaseProviderBaseWithVersionTableLock(Func<DbConnection> connectionFactory)
+        /// <param name="ensurePrerequisitesCreated">Flag provided to ensure that the schema (if appropriate) and version table are created</param>
+        public DatabaseProviderBaseWithVersionTableLock(Func<DbConnection> connectionFactory, bool ensurePrerequisitesCreated)
+            : base(ensurePrerequisitesCreated)
         {
             this.ConnectionFactory = connectionFactory;
         }

--- a/src/Simple.Migrations/DatabaseProvider/MssqlDatabaseProvider.cs
+++ b/src/Simple.Migrations/DatabaseProvider/MssqlDatabaseProvider.cs
@@ -26,8 +26,9 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="MssqlDatabaseProvider"/> class
         /// </summary>
         /// <param name="connection">Connection to use to run migrations. The caller is responsible for closing this.</param>
-        public MssqlDatabaseProvider(DbConnection connection)
-            : base(connection)
+        /// <param name="ensurePrerequisitesCreated">Flag provided to ensure that the schema (if appropriate) and version table are created</param>
+        public MssqlDatabaseProvider(DbConnection connection, bool ensurePrerequisitesCreated = true)
+            : base(connection, ensurePrerequisitesCreated)
         {
             this.MaxDescriptionLength = 256;
         }

--- a/src/Simple.Migrations/DatabaseProvider/MysqlDatabaseProvider.cs
+++ b/src/Simple.Migrations/DatabaseProvider/MysqlDatabaseProvider.cs
@@ -20,8 +20,9 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="MysqlDatabaseProvider"/> class
         /// </summary>
         /// <param name="connection">Connection to use to run migrations. The caller is responsible for closing this.</param>
-        public MysqlDatabaseProvider(DbConnection connection)
-            : base(connection)
+        /// <param name="ensurePrerequisitesCreated">Flag provided to ensure that the schema (if appropriate) and version table are created</param>
+        public MysqlDatabaseProvider(DbConnection connection, bool ensurePrerequisitesCreated = true)
+            : base(connection, ensurePrerequisitesCreated)
         {
         }
 

--- a/src/Simple.Migrations/DatabaseProvider/PostgresqlDatabaseProvider.cs
+++ b/src/Simple.Migrations/DatabaseProvider/PostgresqlDatabaseProvider.cs
@@ -24,8 +24,9 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="PostgresqlDatabaseProvider"/> class
         /// </summary>
         /// <param name="connection">Connection to use to run migrations. The caller is responsible for closing this.</param>
-        public PostgresqlDatabaseProvider(DbConnection connection)
-            : base(connection)
+        /// <param name="ensurePrerequisitesCreated">Flag provided to ensure that the schema (if appropriate) and version table are created</param>
+        public PostgresqlDatabaseProvider(DbConnection connection, bool ensurePrerequisitesCreated = true)
+            : base(connection, ensurePrerequisitesCreated)
         {
         }
 

--- a/src/Simple.Migrations/DatabaseProvider/SqliteDatabaseProvider.cs
+++ b/src/Simple.Migrations/DatabaseProvider/SqliteDatabaseProvider.cs
@@ -18,8 +18,9 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="SqliteDatabaseProvider"/> class
         /// </summary>
         /// <param name="connection">Connection to use to run migrations. The caller is responsible for closing this.</param>
-        public SqliteDatabaseProvider(DbConnection connection)
-            : base(connection)
+        /// <param name="ensurePrerequisitesCreated">Flag provided to ensure that the schema (if appropriate) and version table are created</param>
+        public SqliteDatabaseProvider(DbConnection connection, bool ensurePrerequisitesCreated = true)
+            : base(connection, ensurePrerequisitesCreated)
         {
         }
 

--- a/src/Simple.Migrations/IDatabaseProvider.cs
+++ b/src/Simple.Migrations/IDatabaseProvider.cs
@@ -38,6 +38,15 @@ namespace SimpleMigrations
     public interface IDatabaseProvider<TConnection>
     {
         /// <summary>
+        /// Flag to ensure that the schema (if appropriate) and version table are created.
+        /// </summary>
+        /// <remarks>
+        /// Setting this to true will make the migrator to create the schema and version table,
+        /// otherwise it will be assumed they exist already.
+        /// </remarks>
+        bool EnsurePrerequisitesCreated { get; }
+
+        /// <summary>
         /// Called when <see cref="SimpleMigrator{TConnection, TMigrationBase}.MigrateTo(long)"/> or <see cref="SimpleMigrator{TConnection, TMigrationBase}.Baseline(long)"/>
         /// is invoked, before any migrations are run. This should create connections and/or transactions and/or locks if necessary,
         /// and return the connection for the migrations to use.

--- a/src/Simple.Migrations/SimpleMigrator`2.cs
+++ b/src/Simple.Migrations/SimpleMigrator`2.cs
@@ -118,7 +118,12 @@ namespace SimpleMigrations
                 this.FindAndSetMigrations();
             }
 
-            long currentVersion = this.DatabaseProvider.EnsurePrerequisitesCreatedAndGetCurrentVersion();
+            long currentVersion;
+
+            currentVersion = this.DatabaseProvider.EnsurePrerequisitesCreated
+                ? this.DatabaseProvider.EnsurePrerequisitesCreatedAndGetCurrentVersion()
+                : this.DatabaseProvider.GetCurrentVersion();
+
             this.SetCurrentVersion(currentVersion);
 
             this.isLoaded = true;


### PR DESCRIPTION
Right now the migrator ensures that the schema and VersionInfo tables are created by running two SQL queries. In PostgreSQL (at least), creating the schema requires database ownership which is not optimal when having multiple schemas used by different applications that need to be isolated within their own roles. This commit gives the option of skipping these 2 commands assuming the ensurances are true and making the migrations work in schema-limited ownership environments.