### PR TITLE
Use the IDb interfaces instead of concrete implementations.

### DIFF
--- a/src/Simple.Migrations.IntegrationTests/Mssql/MssqlTests.cs
+++ b/src/Simple.Migrations.IntegrationTests/Mssql/MssqlTests.cs
@@ -18,9 +18,9 @@ namespace Simple.Migrations.IntegrationTests.Mssql
 
         protected override bool SupportConcurrentMigrators => true;
 
-        protected override DbConnection CreateConnection() => new SqlConnection(ConnectionStrings.MSSQL);
+        protected override IDbConnection CreateConnection() => new SqlConnection(ConnectionStrings.MSSQL);
 
-        protected override IDatabaseProvider<DbConnection> CreateDatabaseProvider() => new MssqlDatabaseProvider(this.CreateConnection());
+        protected override IDatabaseProvider<IDbConnection> CreateDatabaseProvider() => new MssqlDatabaseProvider(this.CreateConnection());
 
         protected override void Clean()
         {

--- a/src/Simple.Migrations.IntegrationTests/Mysql/MysqlTests.cs
+++ b/src/Simple.Migrations.IntegrationTests/Mysql/MysqlTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,9 +16,9 @@ namespace Simple.Migrations.IntegrationTests.Mysql
     {
         protected override IMigrationStringsProvider MigrationStringsProvider { get; } = new MysqlStringsProvider();
 
-        protected override DbConnection CreateConnection() => new MySqlConnection(ConnectionStrings.MySQL);
+        protected override IDbConnection CreateConnection() => new MySqlConnection(ConnectionStrings.MySQL);
 
-        protected override IDatabaseProvider<DbConnection> CreateDatabaseProvider() => new MysqlDatabaseProvider(this.CreateConnection());
+        protected override IDatabaseProvider<IDbConnection> CreateDatabaseProvider() => new MysqlDatabaseProvider(this.CreateConnection());
 
         protected override bool SupportConcurrentMigrators => true;
 

--- a/src/Simple.Migrations.IntegrationTests/Postgresql/PostgresqlTests.cs
+++ b/src/Simple.Migrations.IntegrationTests/Postgresql/PostgresqlTests.cs
@@ -14,7 +14,7 @@ namespace Simple.Migrations.IntegrationTests.Postgresql
     [TestFixture]
     public class PostgresqlTests : TestsBase
     {
-        protected override IDatabaseProvider<DbConnection> CreateDatabaseProvider() => new PostgresqlDatabaseProvider(this.CreateConnection());
+        protected override IDatabaseProvider<IDbConnection> CreateDatabaseProvider() => new PostgresqlDatabaseProvider(this.CreateConnection());
 
         protected override IMigrationStringsProvider MigrationStringsProvider { get; } = new PostgresqlStringsProvider();
 
@@ -33,6 +33,6 @@ namespace Simple.Migrations.IntegrationTests.Postgresql
 
         private NpgsqlConnection CreatePgConnection() => new NpgsqlConnection(ConnectionStrings.PostgreSQL);
 
-        protected override DbConnection CreateConnection() => this.CreatePgConnection();
+        protected override IDbConnection CreateConnection() => this.CreatePgConnection();
     }
 }

--- a/src/Simple.Migrations.IntegrationTests/Sqlite/SqliteTests.cs
+++ b/src/Simple.Migrations.IntegrationTests/Sqlite/SqliteTests.cs
@@ -16,7 +16,7 @@ namespace Simple.Migrations.IntegrationTests.Sqlite
     [TestFixture]
     public class SqliteTests : TestsBase
     {
-        protected override IDatabaseProvider<DbConnection> CreateDatabaseProvider() => new SqliteDatabaseProvider(this.CreateConnection());
+        protected override IDatabaseProvider<IDbConnection> CreateDatabaseProvider() => new SqliteDatabaseProvider(this.CreateConnection());
 
         protected override IMigrationStringsProvider MigrationStringsProvider { get; } = new SqliteStringsProvider();
 
@@ -29,6 +29,6 @@ namespace Simple.Migrations.IntegrationTests.Sqlite
                 File.Delete(db);
         }
 
-        protected override DbConnection CreateConnection() => new SqliteConnection(ConnectionStrings.SQLite);
+        protected override IDbConnection CreateConnection() => new SqliteConnection(ConnectionStrings.SQLite);
     }
 }

--- a/src/Simple.Migrations.IntegrationTests/TestsBase.cs
+++ b/src/Simple.Migrations.IntegrationTests/TestsBase.cs
@@ -13,8 +13,8 @@ namespace Simple.Migrations.IntegrationTests
 {
     public abstract class TestsBase
     {
-        protected abstract DbConnection CreateConnection();
-        protected abstract IDatabaseProvider<DbConnection> CreateDatabaseProvider();
+        protected abstract IDbConnection CreateConnection();
+        protected abstract IDatabaseProvider<IDbConnection> CreateDatabaseProvider();
         protected abstract IMigrationStringsProvider MigrationStringsProvider { get; }
         protected abstract void Clean();
 

--- a/src/Simple.Migrations.UnitTests/DatabaseProviderBaseTests.cs
+++ b/src/Simple.Migrations.UnitTests/DatabaseProviderBaseTests.cs
@@ -31,7 +31,7 @@
 //            public string SetVersionSql = "Set Version SQL";
 //            public override string GetSetVersionSql() => this.SetVersionSql;
 
-//            public override DbConnection BeginOperation()
+//            public override IDbConnection BeginOperation()
 //            {
 //                throw new NotImplementedException();
 //            }

--- a/src/Simple.Migrations.UnitTests/MockDatabaseProvider.cs
+++ b/src/Simple.Migrations.UnitTests/MockDatabaseProvider.cs
@@ -4,15 +4,16 @@ using System.Linq;
 using System.Threading.Tasks;
 using SimpleMigrations;
 using System.Data.Common;
+using System.Data;
 
 namespace Simple.Migrations.UnitTests
 {
-    public abstract class MockDatabaseProvider : IDatabaseProvider<DbConnection>
+    public abstract class MockDatabaseProvider : IDatabaseProvider<IDbConnection>
     {
         public long CurrentVersion;
-        public DbConnection Connection;
+        public IDbConnection Connection;
 
-        public DbConnection BeginOperation()
+        public IDbConnection BeginOperation()
         {
             return this.Connection;
         }

--- a/src/Simple.Migrations.UnitTests/SimpleMigratorLoadTests.cs
+++ b/src/Simple.Migrations.UnitTests/SimpleMigratorLoadTests.cs
@@ -36,18 +36,18 @@ namespace Simple.Migrations.UnitTests
 
         private Mock<DbConnection> connection;
         private Mock<IMigrationProvider> migrationProvider;
-        private Mock<IDatabaseProvider<DbConnection>> databaseProvider;
+        private Mock<IDatabaseProvider<IDbConnection>> databaseProvider;
 
-        private SimpleMigrator<DbConnection, Migration> migrator;
+        private SimpleMigrator<IDbConnection, Migration> migrator;
 
         [SetUp]
         public void SetUp()
         {
             this.connection = new Mock<DbConnection>();
             this.migrationProvider = new Mock<IMigrationProvider>();
-            this.databaseProvider = new Mock<IDatabaseProvider<DbConnection>>();
+            this.databaseProvider = new Mock<IDatabaseProvider<IDbConnection>>();
 
-            this.migrator = new SimpleMigrator<DbConnection, Migration>(this.migrationProvider.Object, this.databaseProvider.Object);
+            this.migrator = new SimpleMigrator<IDbConnection, Migration>(this.migrationProvider.Object, this.databaseProvider.Object);
         }
 
         [Test]

--- a/src/Simple.Migrations.UnitTests/SimpleMigratorMigrateTests.cs
+++ b/src/Simple.Migrations.UnitTests/SimpleMigratorMigrateTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using SimpleMigrations;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Linq;
 using System.Reflection;
@@ -21,7 +22,7 @@ namespace Simple.Migrations.UnitTests
             public static Exception Exception;
             public static Action<Migration1> Callback;
 
-            public new DbConnection Connection => base.Connection;
+            public new IDbConnection Connection => base.Connection;
             public new IMigrationLogger Logger => base.Logger;
 
             public static void Reset()
@@ -75,7 +76,7 @@ namespace Simple.Migrations.UnitTests
 
         private List<MigrationData> migrations;
 
-        private SimpleMigrator<DbConnection, Migration> migrator;
+        private SimpleMigrator<IDbConnection, Migration> migrator;
 
         [SetUp]
         public void SetUp()
@@ -96,7 +97,7 @@ namespace Simple.Migrations.UnitTests
 
             this.logger = new Mock<ILogger>();
 
-            this.migrator = new SimpleMigrator<DbConnection, Migration>(this.migrationProvider.Object, this.databaseProvider.Object, this.logger.Object);
+            this.migrator = new SimpleMigrator<IDbConnection, Migration>(this.migrationProvider.Object, this.databaseProvider.Object, this.logger.Object);
 
             this.migrations = new List<MigrationData>()
             {

--- a/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBase.cs
+++ b/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.Data.Common;
 
 namespace SimpleMigrations.DatabaseProvider
@@ -34,7 +35,7 @@ namespace SimpleMigrations.DatabaseProvider
     /// The subclasses <see cref="DatabaseProviderBaseWithAdvisoryLock"/> and <see cref="DatabaseProviderBaseWithVersionTableLock"/>
     /// encapsulate these concepts.
     /// </remarks>
-    public abstract class DatabaseProviderBase : IDatabaseProvider<DbConnection>
+    public abstract class DatabaseProviderBase : IDatabaseProvider<IDbConnection>
     {
         /// <summary>
         /// Table name used to store version info. Defaults to 'VersionInfo'
@@ -68,7 +69,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <param name="connection">Connection to use</param>
         /// <param name="transaction">Transaction to use</param>
         /// <returns>The current version, or 0</returns>
-        protected virtual long EnsurePrerequisitesCreatedAndGetCurrentVersion(DbConnection connection, DbTransaction transaction)
+        protected virtual long EnsurePrerequisitesCreatedAndGetCurrentVersion(IDbConnection connection, IDbTransaction transaction)
         {
             var createSchemaSql = this.GetCreateSchemaTableSql();
             if (!string.IsNullOrEmpty(createSchemaSql))
@@ -97,7 +98,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// and return the connection for the migrations to use.
         /// </summary>
         /// <returns>Connection for the migrations to use</returns>
-        public abstract DbConnection BeginOperation();
+        public abstract IDbConnection BeginOperation();
 
         /// <summary>
         /// Cleans up any connections and/or transactions and/or locks created by <see cref="BeginOperation"/>
@@ -130,7 +131,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <param name="connection">Connection to use</param>
         /// <param name="transaction">transaction to use, may be null</param>
         /// <returns>The current database schema version, or 0</returns>
-        protected virtual long GetCurrentVersion(DbConnection connection, DbTransaction transaction)
+        protected virtual long GetCurrentVersion(IDbConnection connection, IDbTransaction transaction)
         {
             long version = 0;
             using (var command = connection.CreateCommand())
@@ -176,7 +177,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <param name="newDescription">The description of the migration which was applied</param>
         /// <param name="connection">Connection to use</param>
         /// <param name="transaction">Transaction to use, may be null</param>
-        protected virtual void UpdateVersion(long oldVersion, long newVersion, string newDescription, DbConnection connection, DbTransaction transaction)
+        protected virtual void UpdateVersion(long oldVersion, long newVersion, string newDescription, IDbConnection connection, IDbTransaction transaction)
         {
             if (this.MaxDescriptionLength > 0 && newDescription.Length > this.MaxDescriptionLength)
             {

--- a/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBaseWithAdvisoryLock.cs
+++ b/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBaseWithAdvisoryLock.cs
@@ -16,7 +16,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <summary>
         /// Gets the connection used for all database operations
         /// </summary>
-        protected DbConnection Connection { get; }
+        protected IDbConnection Connection { get; }
 
         /// <summary>
         /// Gets or sets the timeout when acquiring the advisory lock
@@ -27,7 +27,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="DatabaseProviderBaseWithAdvisoryLock"/> class
         /// </summary>
         /// <param name="connection">Database connection to use for all operations</param>
-        public DatabaseProviderBaseWithAdvisoryLock(DbConnection connection)
+        public DatabaseProviderBaseWithAdvisoryLock(IDbConnection connection)
         {
             this.Connection = connection;
             if (this.Connection.State != ConnectionState.Open)
@@ -63,7 +63,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// is invoked, before any migrations are run. This invokes <see cref="AcquireAdvisoryLock"/> to acquire the advisory lock.
         /// </summary>
         /// <returns>Connection for the migrations to use</returns>
-        public override DbConnection BeginOperation()
+        public override IDbConnection BeginOperation()
         {
             this.AcquireAdvisoryLock();
             return this.Connection;

--- a/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBaseWithVersionTableLock.cs
+++ b/src/Simple.Migrations/DatabaseProvider/DatabaseProviderBaseWithVersionTableLock.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.Data.Common;
 
 namespace SimpleMigrations.DatabaseProvider
@@ -25,7 +26,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <remarks>
         /// This is set by <see cref="BeginOperation"/>, and cleated by <see cref="EndOperation"/>.
         /// </remarks>
-        protected DbConnection VersionTableConnection { get; set; }
+        protected IDbConnection VersionTableConnection { get; set; }
 
         /// <summary>
         /// Gets or sets the transaction on the <see cref="VersionTableConnection"/> used to lock it.
@@ -33,7 +34,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <remarks>
         /// This is set by <see cref="BeginOperation"/>, and cleated by <see cref="EndOperation"/>.
         /// </remarks>
-        protected DbTransaction VersionTableLockTransaction { get; set; }
+        protected IDbTransaction VersionTableLockTransaction { get; set; }
 
         /// <summary>
         /// Gets or sets the connection to be used by migrations.
@@ -41,7 +42,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <remarks>
         /// This is set by <see cref="BeginOperation"/>, and cleated by <see cref="EndOperation"/>.
         /// </remarks>
-        protected DbConnection MigrationsConnection { get; set; }
+        protected IDbConnection MigrationsConnection { get; set; }
 
         /// <summary>
         /// Initialises a new instance of the <see cref="DatabaseProviderBaseWithVersionTableLock"/> class
@@ -78,7 +79,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// <see cref="MigrationsConnection"/>, and invokes <see cref="AcquireVersionTableLock"/> to acquire the VersionInfo table lock.
         /// </summary>
         /// <returns>Connection for the migrations to use</returns>
-        public override DbConnection BeginOperation()
+        public override IDbConnection BeginOperation()
         {
             this.VersionTableConnection = this.ConnectionFactory();
             this.VersionTableConnection.Open();

--- a/src/Simple.Migrations/DatabaseProvider/MssqlDatabaseProvider.cs
+++ b/src/Simple.Migrations/DatabaseProvider/MssqlDatabaseProvider.cs
@@ -47,7 +47,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="MssqlDatabaseProvider"/> class
         /// </summary>
         /// <param name="connection">Connection to use to run migrations. The caller is responsible for closing this.</param>
-        public MssqlDatabaseProvider(DbConnection connection)
+        public MssqlDatabaseProvider(IDbConnection connection)
             : base(connection)
         {
             this.MaxDescriptionLength = 256;

--- a/src/Simple.Migrations/DatabaseProvider/MysqlDatabaseProvider.cs
+++ b/src/Simple.Migrations/DatabaseProvider/MysqlDatabaseProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.Data.Common;
 
 namespace SimpleMigrations.DatabaseProvider
@@ -30,7 +31,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="MysqlDatabaseProvider"/> class
         /// </summary>
         /// <param name="connection">Connection to use to run migrations. The caller is responsible for closing this.</param>
-        public MysqlDatabaseProvider(DbConnection connection)
+        public MysqlDatabaseProvider(IDbConnection connection)
             : base(connection)
         {
         }

--- a/src/Simple.Migrations/DatabaseProvider/PostgresqlDatabaseProvider.cs
+++ b/src/Simple.Migrations/DatabaseProvider/PostgresqlDatabaseProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.Data.Common;
 
 namespace SimpleMigrations.DatabaseProvider
@@ -37,7 +38,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="PostgresqlDatabaseProvider"/> class
         /// </summary>
         /// <param name="connection">Connection to use to run migrations. The caller is responsible for closing this.</param>
-        public PostgresqlDatabaseProvider(DbConnection connection)
+        public PostgresqlDatabaseProvider(IDbConnection connection)
             : base(connection)
         {
         }

--- a/src/Simple.Migrations/DatabaseProvider/SqliteDatabaseProvider.cs
+++ b/src/Simple.Migrations/DatabaseProvider/SqliteDatabaseProvider.cs
@@ -18,7 +18,7 @@ namespace SimpleMigrations.DatabaseProvider
         /// Initialises a new instance of the <see cref="SqliteDatabaseProvider"/> class
         /// </summary>
         /// <param name="connection">Connection to use to run migrations. The caller is responsible for closing this.</param>
-        public SqliteDatabaseProvider(DbConnection connection)
+        public SqliteDatabaseProvider(IDbConnection connection)
             : base(connection)
         {
         }

--- a/src/Simple.Migrations/Migration.cs
+++ b/src/Simple.Migrations/Migration.cs
@@ -8,7 +8,7 @@ namespace SimpleMigrations
     /// Base class, intended to be used by all migrations (although you may implement <see cref="IMigration{TDatabase}"/> directly if you wish).
     /// Migrations MUST apply the <see cref="MigrationAttribute"/> attribute
     /// </summary>
-    public abstract class Migration : IMigration<DbConnection>
+    public abstract class Migration : IMigration<IDbConnection>
     {
         /// <summary>
         /// Gets or sets a value indicating whether calls to <see cref="Execute(string, int?)"/> should be run inside of a transaction.
@@ -21,7 +21,7 @@ namespace SimpleMigrations
         /// <summary>
         /// Gets or sets the database to be used by this migration
         /// </summary>
-        protected DbConnection Connection { get; private set; }
+        protected IDbConnection Connection { get; private set; }
 
         /// <summary>
         /// Gets or sets the logger to be used by this migration
@@ -34,7 +34,7 @@ namespace SimpleMigrations
         /// <remarks>
         /// This is set only if <see cref="UseTransaction"/> is true.
         /// </remarks>
-        protected DbTransaction Transaction { get; private set; }
+        protected IDbTransaction Transaction { get; private set; }
 
         // Up and Down should really be 'protected', but in the name of backwards compatibility...
 
@@ -79,7 +79,7 @@ namespace SimpleMigrations
         /// A <see cref="DbCommand"/> which is configured with the <see cref="DbCommand.CommandText"/>, <see cref="DbCommand.Transaction"/>,
         /// and <see cref="DbCommand.CommandTimeout"/> properties set.
         /// </returns>
-        protected virtual DbCommand CreateCommand(string sql, int? commandTimeout)
+        protected virtual IDbCommand CreateCommand(string sql, int? commandTimeout)
         {
             if (this.Connection == null)
                 throw new InvalidOperationException("this.Connection has not yet been set. This should have been set by Execute(DbConnection, IMigrationLogger, MigrationDirection)");
@@ -94,7 +94,7 @@ namespace SimpleMigrations
             return command;
         }
 
-        void IMigration<DbConnection>.RunMigration(MigrationRunData<DbConnection> data)
+        void IMigration<IDbConnection>.RunMigration(MigrationRunData<IDbConnection> data)
         {
             this.Connection = data.Connection;
             this.Logger = data.Logger;

--- a/src/Simple.Migrations/SimpleMigrator.cs
+++ b/src/Simple.Migrations/SimpleMigrator.cs
@@ -8,7 +8,7 @@ namespace SimpleMigrations
     /// <summary>
     /// Migrator which uses <see cref="IDbConnection"/> connections
     /// </summary>
-    public class SimpleMigrator : SimpleMigrator<DbConnection, IMigration<DbConnection>>
+    public class SimpleMigrator : SimpleMigrator<IDbConnection, IMigration<IDbConnection>>
     {
         /// <summary>
         /// Instantiates a new instance of the <see cref="SimpleMigrator"/> class
@@ -18,7 +18,7 @@ namespace SimpleMigrations
         /// <param name="logger">Logger to use to log progress</param>
         public SimpleMigrator(
             IMigrationProvider migrationProvider,
-            IDatabaseProvider<DbConnection> databaseProvider,
+            IDatabaseProvider<IDbConnection> databaseProvider,
             ILogger logger = null)
             : base(migrationProvider, databaseProvider, logger)
         {
@@ -32,7 +32,7 @@ namespace SimpleMigrations
         /// <param name="logger">Logger to use to log progress</param>
         public SimpleMigrator(
             Assembly migrationsAssembly,
-            IDatabaseProvider<DbConnection> databaseProvider,
+            IDatabaseProvider<IDbConnection> databaseProvider,
             ILogger logger = null)
             : base(migrationsAssembly, databaseProvider, logger)
         {


### PR DESCRIPTION
This would allow me to use ServiceStack.OrmLite's connections.